### PR TITLE
feat(import): add group assignment and skip-confirmation setting

### DIFF
--- a/src/NebulaAuth/Core/DialogsController.cs
+++ b/src/NebulaAuth/Core/DialogsController.cs
@@ -73,6 +73,22 @@ public static class DialogsController
         return null;
     }
 
+    public static async Task<MafileImportDialogResult?> ShowMafileImportDialog(IEnumerable<string> groups,
+        int totalCount, int conflictCount)
+    {
+        var vm = new MafileImportDialogVM(groups, totalCount, conflictCount);
+        var content = new MafileImportDialog
+        {
+            DataContext = vm
+        };
+        var result = await DialogHost.Show(content);
+        return result is MafileImportDialogVM
+            ? new MafileImportDialogResult(
+                !vm.AddToGroup || string.IsNullOrWhiteSpace(vm.Group) ? null : vm.Group.Trim(),
+                vm.OverwriteConflicts)
+            : null;
+    }
+
     public static async Task<bool> ShowProxyManager()
     {
         var vm = new ProxyManagerVM();

--- a/src/NebulaAuth/Localization/dialogs.loc.json
+++ b/src/NebulaAuth/Localization/dialogs.loc.json
@@ -35,5 +35,67 @@
       "tr": "Değer girin",
       "kk": "Мән енгізіңіз"
     }
+  },
+  "MafileImportDialog": {
+    "Title": {
+      "en": "Mafile import",
+      "ru": "Импорт мафайлов",
+      "zh": "导入 mafile",
+      "uk": "Імпорт mafile",
+      "fr": "Import de mafiles",
+      "es": "Importación de mafiles",
+      "tr": "Mafile içe aktarma",
+      "kk": "Mafile импорттау"
+    },
+    "TotalCount": {
+      "en": "Mafiles to import",
+      "ru": "Мафайлов к импорту",
+      "zh": "要导入的 mafile：",
+      "uk": "Mafile до імпорту:",
+      "fr": "Mafiles à importer :",
+      "es": "Mafiles para importar:",
+      "tr": "İçe aktarılacak mafile:",
+      "kk": "Импортталатын mafile:"
+    },
+    "ConflictCount": {
+      "en": "Already exist",
+      "ru": "Уже существуют",
+      "zh": "已存在：",
+      "uk": "Уже існують:",
+      "fr": "Déjà existants :",
+      "es": "Ya existen:",
+      "tr": "Zaten mevcut:",
+      "kk": "Бұрыннан бар:"
+    },
+    "OverwriteConflicts": {
+      "en": "Overwrite conflicting mafiles",
+      "ru": "Перезаписать конфликтующие мафайлы",
+      "zh": "覆盖冲突的 mafile",
+      "uk": "Перезаписати конфліктні mafile",
+      "fr": "Remplacer les mafiles en conflit",
+      "es": "Sobrescribir mafiles en conflicto",
+      "tr": "Çakışan mafile'ların üzerine yaz",
+      "kk": "Қақтығысатын mafile файлдарын қайта жазу"
+    },
+    "AddToGroup": {
+      "en": "Add imported accounts to a group",
+      "ru": "Добавить импортированные аккаунты в группу",
+      "zh": "将导入的账号添加到组",
+      "uk": "Додати імпортовані акаунти до групи",
+      "fr": "Ajouter les comptes importés à un groupe",
+      "es": "Añadir las cuentas importadas a un grupo",
+      "tr": "İçe aktarılan hesapları bir gruba ekle",
+      "kk": "Импортталған аккаунттарды топқа қосу"
+    },
+    "GroupFieldHint": {
+      "en": "Existing or new group",
+      "ru": "Существующая или новая группа",
+      "zh": "现有或新组",
+      "uk": "Наявна або нова група",
+      "fr": "Groupe existant ou nouveau",
+      "es": "Grupo existente o nuevo",
+      "tr": "Mevcut veya yeni grup",
+      "kk": "Бар немесе жаңа топ"
+    }
   }
 }

--- a/src/NebulaAuth/Localization/dialogs.settings.loc.json
+++ b/src/NebulaAuth/Localization/dialogs.settings.loc.json
@@ -262,25 +262,25 @@
         "kk": "Дискке сақталмайды"
       }
     },
-    "LegacyMafileMode": {
-      "en": "Common mafiles format",
-      "ru": "Общепринятый формат мафайлов",
-      "zh": "常见的邮件文件格式",
-      "uk": "Загальноприйнятий формат мафайлів",
-      "fr": "Format de mafiles commun",
-      "es": "Formato común de mafiles",
-      "tr": "Ortak mafile formatı",
-      "kk": "Жалпы mafile форматы"
+    "ConfirmMafileImport": {
+      "en": "Ask confirmation when importing mafiles",
+      "ru": "Спрашивать подтверждение при импорте мафайлов",
+      "zh": "导入 mafile 时请求确认",
+      "uk": "Запитувати підтвердження під час імпорту mafile",
+      "fr": "Demander confirmation lors de l'import des mafiles",
+      "es": "Pedir confirmación al importar mafiles",
+      "tr": "Mafile içe aktarırken onay sor",
+      "kk": "Mafile импорттау кезінде растауды сұрау"
     },
-    "LegacyMafileModeHint": {
-      "en": "Save mafiles in compatibility format with Steam Desktop Authenticator and other applications",
-      "ru": "Сохранять мафайлы в старом формате для совместимости со Steam Desktop Authenticator и другими приложениями",
-      "zh": "以与 Steam 桌面认证器及其他应用程序兼容的格式保存 mafiles",
-      "uk": "Зберігати мафайли у старому форматі для сумісності зі Steam Desktop Authenticator та іншими додатками",
-      "fr": "Enregistrer les mafiles dans un format compatible avec Steam Desktop Authenticator et d'autres applications",
-      "es": "Guardar mafiles en formato compatible con Steam Desktop Authenticator y otras aplicaciones",
-      "tr": "Mafile'ları Steam Desktop Authenticator ve diğer uygulamalarla uyumlu formatta kaydet",
-      "kk": "Mafile файлдарын Steam Desktop Authenticator және басқа қолданбалармен үйлесімді форматта сақтау"
+    "ConfirmMafileImportHint": {
+      "en": "Allows selecting a group when importing maFiles. Does not affect showing the dialog when file conflicts occur",
+      "ru": "Позволяет выбрать группу при импорте maFiles. Не влияет на показ окна при конфликте файлов",
+      "zh": "允许在导入 maFiles 时选择分组。不影响发生文件冲突时窗口的显示",
+      "uk": "Дозволяє вибрати групу під час імпорту maFiles. Не впливає на показ вікна при конфлікті файлів",
+      "fr": "Permet de choisir un groupe lors de l'import des maFiles. N'affecte pas l'affichage de la fenêtre en cas de conflit de fichiers",
+      "es": "Permite seleccionar un grupo al importar maFiles. No afecta a la aparición de la ventana cuando hay conflictos de archivos",
+      "tr": "maFiles içe aktarılırken grup seçilmesine izin verir. Dosya çakışmalarında pencerenin gösterilmesini etkilemez",
+      "kk": "maFiles импорттау кезінде топ таңдауға мүмкіндік береді. Файл қайшылықтары болғанда терезенің көрсетілуіне әсер етпейді"
     },
     "AllowAutoUpdate": {
       "en": "Allow auto update",

--- a/src/NebulaAuth/Localization/mainwindow.loc.json
+++ b/src/NebulaAuth/Localization/mainwindow.loc.json
@@ -101,16 +101,6 @@
         "tr": "Onay hatası",
         "kk": "Растау қатесі"
       },
-      "ConfirmMafileOverwrite": {
-        "ru": "Внимание, мафайл(-ы) уже присутствует в папке mafiles.\r\nПерезаписать мафайлы, которые конфликтуют?",
-        "en": "Attention, mafile(-s) already exists in mafiles folder.\r\nOverwrite conflicting mafiles?",
-        "zh": "注意，mafile 已经存在于 mafiles 文件夹中。\r\n覆盖冲突的 mafiles 吗？",
-        "uk": "Увага, мафайл(-и) вже присутній у папці mafiles.\r\nПерезаписати мафайли, які конфліктують?",
-        "fr": "Attention, mafiles déjà présents dans le dossier mafiles.\r\nRemplacer les mafiles en conflit?",
-        "es": "Atención, los mafiles ya existen en la carpeta mafiles.\r\n¿Sobrescribir los mafiles en conflicto?",
-        "tr": "Dikkat, mafile(ler) zaten mafiles klasöründe mevcut.\r\nÇakışan mafile'lar üzerine yazılsın mı?",
-        "kk": "Назар аударыңыз, mafile(дер) mafiles қалтасында бар.\r\nҚайшылық тудырған mafile файлдарының үстінен жазу керек пе?"
-      },
       "MafileImportError": {
         "ru": "Ошибка при импорте мафайла",
         "en": "Mafile import error",

--- a/src/NebulaAuth/Model/NebulaSerializer.cs
+++ b/src/NebulaAuth/Model/NebulaSerializer.cs
@@ -85,11 +85,6 @@ public static class NebulaSerializer
 
     public static string SerializeMafile(MobileDataExtended data, Dictionary<string, object?>? properties)
     {
-        if (Settings.Instance.LegacyMode)
-        {
-            return MafileSerializer.SerializeLegacy(data, Serializer.Settings.SerializationOptions, properties);
-        }
-
-        return Serializer.Serialize(data);
+        return MafileSerializer.SerializeLegacy(data, Serializer.Settings.SerializationOptions, properties);
     }
 }

--- a/src/NebulaAuth/Model/Settings.cs
+++ b/src/NebulaAuth/Model/Settings.cs
@@ -91,7 +91,7 @@ public partial class Settings : ObservableObject
     [ObservableProperty] private Color? _iconColor;
     [ObservableProperty] private bool _isPasswordSet;
     [ObservableProperty] private LocalizationLanguage _language = LocalizationLanguage.English;
-    [ObservableProperty] private bool _legacyMode = true;
+    [ObservableProperty] private bool _confirmMafileImport = true;
     [ObservableProperty] private bool _allowAutoUpdate;
     [ObservableProperty] private bool _useAccountNameAsMafileName;
 

--- a/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml
@@ -1,0 +1,129 @@
+<UserControl x:Class="NebulaAuth.View.Dialogs.MafileImportDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             Height="Auto" Width="Auto" MaxWidth="520"
+             Background="{DynamicResource WindowBackground}">
+    <Grid MinHeight="240" MinWidth="440">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Margin="10,10,10,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Center" FontSize="18" Text="{Tr MafileImportDialog.Title}" />
+            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
+                    HorizontalAlignment="Right" CommandParameter="{x:Null}"
+                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
+                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
+            </Button>
+        </Grid>
+
+        <Separator Grid.Row="1" Opacity="0.7" />
+
+        <Grid Grid.Row="2" Margin="14,14,14,16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Margin="6,0,6,12" Padding="12,10"
+                    CornerRadius="8"
+                    BorderThickness="1">
+                <Border.Background>
+                    <SolidColorBrush Color="{DynamicResource BaseContentColor}" Opacity="0.07"/>
+                </Border.Background>
+                <Border.BorderBrush>
+                    <SolidColorBrush Color="{DynamicResource BaseContentColor}" Opacity="0.12"/>
+                </Border.BorderBrush>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="{Tr MafileImportDialog.TotalCount}" Opacity="0.82" />
+                    <TextBlock Grid.Column="1" Text="{Binding TotalCount, Mode=OneWay}" FontWeight="SemiBold" />
+
+                    <TextBlock Grid.Row="1" Text="{Tr MafileImportDialog.ConflictCount}" Opacity="0.82"
+                               Visibility="{Binding HasConflicts, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding ConflictCount, Mode=OneWay}"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource WarningBrush}"
+                               Visibility="{Binding HasConflicts, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+            </Border>
+
+            <CheckBox Grid.Row="1"
+                      Margin="10,4,10,8"
+                      IsChecked="{Binding OverwriteConflicts}"
+                      Visibility="{Binding HasConflicts, Converter={StaticResource BooleanToVisibilityConverter}}"
+                      Content="{Tr MafileImportDialog.OverwriteConflicts}" />
+
+            <Separator Grid.Row="2"
+                       Margin="10,2,10,2" Opacity="0.35"
+                       Visibility="{Binding HasConflicts, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <CheckBox Grid.Row="3"
+                      Margin="10,4,10,0"
+                      IsChecked="{Binding AddToGroup}"
+                      Content="{Tr MafileImportDialog.AddToGroup}" />
+
+            <ComboBox x:Name="GroupBox"
+                      Grid.Row="4"
+                      Margin="42,0,10,0"
+                      IsEditable="True"
+                      ItemsSource="{Binding Groups}"
+                      
+                      Text="{Binding Group, UpdateSourceTrigger=PropertyChanged}"
+                      materialDesign:HintAssist.Hint="{Tr MafileImportDialog.GroupFieldHint}"
+                      materialDesign:HintAssist.IsFloating="False"
+                      Visibility="{Binding AddToGroup, Converter={StaticResource BooleanToVisibilityConverter}}"
+                      Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                   
+                      />
+
+            <Grid Grid.Row="5" Margin="10,16,10,5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <Button Width="130"
+                        HorizontalAlignment="Left"
+                        Margin="2,0,4,0"
+                        Style="{StaticResource MaterialDesignFlatDarkBgButton}"
+                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{Binding}"
+                        Content="{Tr Common.OK}"
+                        IsDefault="True" />
+                <Button Grid.Column="1"
+                        HorizontalAlignment="Right"
+                        Width="130"
+                        Margin="0,0,2,0"
+                        Style="{StaticResource MaterialDesignOutlinedButton}"
+                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{x:Null}"
+                        Content="{Tr Common.Cancel}"
+                        IsCancel="True" />
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml.cs
+++ b/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml.cs
@@ -1,0 +1,9 @@
+namespace NebulaAuth.View.Dialogs;
+
+public partial class MafileImportDialog
+{
+    public MafileImportDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NebulaAuth/View/SettingsView.xaml
+++ b/src/NebulaAuth/View/SettingsView.xaml
@@ -59,9 +59,9 @@
                                   Content="{Tr SettingsDialog.MinimizeToTray}" />
 
 
-                        <CheckBox Margin="0,5,0,0" IsChecked="{Binding LegacyMode}"
-                                  Content="{Tr SettingsDialog.LegacyMafileMode}"
-                                  ToolTip="{Tr SettingsDialog.LegacyMafileModeHint}" />
+                        <CheckBox Margin="0,5,0,0" IsChecked="{Binding ConfirmMafileImport}"
+                                  Content="{Tr SettingsDialog.ConfirmMafileImport}"
+                                  ToolTip="{Tr SettingsDialog.ConfirmMafileImportHint}" />
                         <!--<CheckBox IsEnabled="False"  Margin="0,10,0,0"  FontSize="16" IsChecked="{Binding AllowAutoUpdate}" Content="{Tr SettingsDialog.AllowAutoUpdate}"/>-->
 
                         <!--<CheckBox Margin="0,12,0,0"  IsChecked="{Binding UseAccountNameAsMafileName}">

--- a/src/NebulaAuth/ViewModel/MainVM_File.cs
+++ b/src/NebulaAuth/ViewModel/MainVM_File.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
@@ -71,10 +72,11 @@ public partial class MainVM //File //TODO: Refactor
             : Task.CompletedTask;
     }
 
+    //TODO: extract flow and refactor, this method is too long and does too many things
     public async Task AddMafile(string[] path)
     {
-        bool? confirmOverwrite = null;
         var summary = new MafileImportSummary();
+        var items = new List<MafileImportPlanItem>();
         SDAEncryptionHelper.Context? sdaContext = null;
         var sdaPasswordPrompted = false;
         foreach (var str in path)
@@ -90,16 +92,7 @@ public partial class MainVM //File //TODO: Refactor
                     continue;
                 }
 
-                var overwrite = confirmOverwrite ?? false;
-                var res = await Storage.AddNewMafileFromData(mafile, overwrite);
-                if (res == AddMafileResult.AlreadyExist && confirmOverwrite == null)
-                {
-                    confirmOverwrite =
-                        await DialogsController.ShowConfirmCancelDialog(GetLocalization("ConfirmMafileOverwrite"));
-                    res = await Storage.AddNewMafileFromData(mafile, confirmOverwrite.Value);
-                }
-
-                summary.Apply(res);
+                items.Add(new MafileImportPlanItem(mafile, false, HasImportConflict(mafile)));
             }
             catch (FormatException)
             {
@@ -109,18 +102,11 @@ public partial class MainVM //File //TODO: Refactor
             {
                 if (path.Length == 1 && ex.Mafile != null)
                 {
-                    var mafile = ex.Mafile;
-                    if (await HandleAddMafileWithoutSession(mafile))
-                    {
-                        summary.AddedOne();
-                    }
-                    else
-                    {
-                        summary.ErrorOne();
-                    }
+                    items.Add(new MafileImportPlanItem(ex.Mafile, true, HasImportConflict(ex.Mafile)));
                 }
                 else
                 {
+                    summary.ErrorOne();
                     SnackbarController.SendSnackbar(
                         $"{GetLocalization("MafileImportError")} {Path.GetFileName(str)}{GetLocalization("MissingSessionInMafile")}",
                         TimeSpan.FromSeconds(4));
@@ -128,7 +114,76 @@ public partial class MainVM //File //TODO: Refactor
             }
         }
 
+        if (items.Count == 0)
+        {
+            ShowImportSummary(summary);
+            return;
+        }
+
+        var conflictCount = items.Count(i => i.HasConflict);
+        var showImportDialog = Settings.ConfirmMafileImport || conflictCount > 0;
+        MafileImportDialogResult? importOptions = null;
+        if (showImportDialog)
+        {
+            importOptions = await DialogsController.ShowMafileImportDialog(Groups, items.Count, conflictCount);
+            if (importOptions == null)
+            {
+                SnackbarController.SendSnackbar(LocManager.GetCommonOrDefault("Canceled", "Canceled"));
+                return;
+            }
+        }
+
+        var importGroup = importOptions?.Group;
+        var overwriteConflicts = importOptions?.OverwriteConflicts ?? false;
+        foreach (var item in items)
+        {
+            ApplyImportGroup(item.Mafile, importGroup);
+            if (item.RequiresRelogin)
+            {
+                if (item.HasConflict && !overwriteConflicts)
+                {
+                    summary.SkippedOne();
+                    continue;
+                }
+
+                if (await HandleAddMafileWithoutSession(item.Mafile))
+                {
+                    summary.AddedOne();
+                }
+                else
+                {
+                    summary.ErrorOne();
+                }
+
+                continue;
+            }
+
+            var res = await Storage.AddNewMafileFromData(item.Mafile, overwriteConflicts);
+            summary.Apply(res);
+        }
+
+        if (summary.Added > 0)
+        {
+            QueryGroups();
+            if (!string.IsNullOrWhiteSpace(importGroup))
+            {
+                SelectedGroup = importGroup;
+            }
+        }
+
         ShowImportSummary(summary);
+    }
+
+    private static void ApplyImportGroup(Mafile mafile, string? group)
+    {
+        if (string.IsNullOrWhiteSpace(group)) return;
+        mafile.Group = group;
+    }
+
+    private static bool HasImportConflict(Mafile mafile)
+    {
+        var fileName = MafilesStorageHelper.CreateMafileFileName(mafile, Settings.Instance.UseAccountNameAsMafileName);
+        return File.Exists(Path.Combine(Storage.MafilesDirectory, fileName));
     }
 
 
@@ -213,6 +268,7 @@ public partial class MainVM //File //TODO: Refactor
 
         var result = data.SessionData != null;
         if (!result) return result;
+        data.Filename = null;
         await Storage.SaveMafileAsync(data);
         {
             ResetQuery();
@@ -352,4 +408,6 @@ public partial class MainVM //File //TODO: Refactor
         Mafile? Mafile,
         bool SdaPasswordPrompted,
         SDAEncryptionHelper.Context? SdaContext);
+
+    private record MafileImportPlanItem(Mafile Mafile, bool RequiresRelogin, bool HasConflict);
 }

--- a/src/NebulaAuth/ViewModel/Other/SettingsVM.cs
+++ b/src/NebulaAuth/ViewModel/Other/SettingsVM.cs
@@ -168,10 +168,10 @@ public partial class SettingsVM : ObservableObject
         }
     }
 
-    public bool LegacyMode
+    public bool ConfirmMafileImport
     {
-        get => Settings.LegacyMode;
-        set => Settings.LegacyMode = value;
+        get => Settings.ConfirmMafileImport;
+        set => Settings.ConfirmMafileImport = value;
     }
 
     public bool AllowAutoUpdate


### PR DESCRIPTION
## Summary

Improve the mafile import workflow by allowing direct group assignment during import, making the confirmation dialog optional when no conflicts are detected (now shown by default), and removing the obsolete legacy mafile format setting.

## Changes

- Add ability to assign imported mafiles to a group directly from the import dialog
- Add setting to skip the import confirmation dialog when no conflicts are detected
- Remove the deprecated "legacy mafile format" setting as it is no longer relevant