### PR TITLE
feat(proxy): add SignAtScheme support for improved proxy parsing

### DIFF
--- a/src/NebulaAuth/Model/ProxyStorage.cs
+++ b/src/NebulaAuth/Model/ProxyStorage.cs
@@ -22,6 +22,13 @@ public static class ProxyStorage
         PatternRequirement.Optional,
         PatternRequirement.Optional);
 
+    public static readonly ProxyParser SignAtScheme = new(
+        ProxyDefaultFormats.UniversalSignAt, false, ProxyProtocol.HTTP,
+        ProxyPatternProtocol.All,
+        ProxyPatternHostFormat.Domain | ProxyPatternHostFormat.IPv4,
+        PatternRequirement.Required,
+        PatternRequirement.Required);
+
 
     public static ObservableDictionary<int, ProxyData> Proxies { get; } = new();
 


### PR DESCRIPTION
## Summary

Add support for proxy strings in the `login:pass@ip:port` and `protocol://login:pass@ip:port` formats.