### PR TITLE
feat(ui): add DialogHeader component and restyle dialog headers

### DIFF
--- a/src/NebulaAuth/Components/DialogHeader.xaml
+++ b/src/NebulaAuth/Components/DialogHeader.xaml
@@ -1,0 +1,49 @@
+<UserControl x:Class="NebulaAuth.DialogHeader"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             x:Name="Root">
+    <StackPanel>
+        <Border Background="{DynamicResource Base300Brush}" Padding="10,6,10,6">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon
+                        Kind="{Binding IconKind, ElementName=Root}"
+                        Width="20" Height="20" Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource PrimaryContentBrush}">
+                        <materialDesign:PackIcon.Style>
+                            <Style TargetType="materialDesign:PackIcon">
+                                <Style.Triggers>
+                                    <Trigger Property="Kind" Value="None">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </materialDesign:PackIcon.Style>
+                    </materialDesign:PackIcon>
+                    <TextBlock VerticalAlignment="Center"
+                               Foreground="{DynamicResource PrimaryContentBrush}"
+                               FontSize="18">
+                        <Run Text="{Binding Title, ElementName=Root}" />
+                        <Run FontWeight="Bold" Text="{Binding TitleAccent, ElementName=Root}" />
+                    </TextBlock>
+                </StackPanel>
+                <Button Grid.Column="1" Width="30" Height="30"
+                        Style="{StaticResource MaterialDesignIconForegroundButton}"
+                        HorizontalAlignment="Right"
+                        IsEnabled="{Binding IsCloseEnabled, ElementName=Root}"
+                        Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                        CommandParameter="{Binding CloseParameter, ElementName=Root}">
+                    <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
+                </Button>
+            </Grid>
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/src/NebulaAuth/Components/DialogHeader.xaml.cs
+++ b/src/NebulaAuth/Components/DialogHeader.xaml.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using System.Windows.Controls;
+using MaterialDesignThemes.Wpf;
+
+namespace NebulaAuth;
+
+public partial class DialogHeader : UserControl
+{
+    public static readonly DependencyProperty IconKindProperty =
+        DependencyProperty.Register(nameof(IconKind), typeof(PackIconKind), typeof(DialogHeader),
+            new PropertyMetadata(PackIconKind.None));
+
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(nameof(Title), typeof(string), typeof(DialogHeader),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty TitleAccentProperty =
+        DependencyProperty.Register(nameof(TitleAccent), typeof(string), typeof(DialogHeader),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty CloseParameterProperty =
+        DependencyProperty.Register(nameof(CloseParameter), typeof(object), typeof(DialogHeader),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty IsCloseEnabledProperty =
+        DependencyProperty.Register(nameof(IsCloseEnabled), typeof(bool), typeof(DialogHeader),
+            new PropertyMetadata(true));
+
+    public PackIconKind IconKind
+    {
+        get => (PackIconKind) GetValue(IconKindProperty);
+        set => SetValue(IconKindProperty, value);
+    }
+
+    public string? Title
+    {
+        get => (string?) GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public string? TitleAccent
+    {
+        get => (string?) GetValue(TitleAccentProperty);
+        set => SetValue(TitleAccentProperty, value);
+    }
+
+    public object? CloseParameter
+    {
+        get => GetValue(CloseParameterProperty);
+        set => SetValue(CloseParameterProperty, value);
+    }
+
+    public bool IsCloseEnabled
+    {
+        get => (bool) GetValue(IsCloseEnabledProperty);
+        set => SetValue(IsCloseEnabledProperty, value);
+    }
+
+    public DialogHeader()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NebulaAuth/MainWindow.xaml
+++ b/src/NebulaAuth/MainWindow.xaml
@@ -42,6 +42,7 @@
                        DialogClosed="DialogHost_DialogClosed"
                        ApplyBlurBackground="{Binding Settings.ApplyBlurBackground}"
                        BlurRadius="12"
+                       DialogContentUniformCornerRadius="12"
                        x:Name="DialogHostInstance">
 
             <Grid ZIndex="0">

--- a/src/NebulaAuth/Theme/WindowStyle/WindowStyle.xaml
+++ b/src/NebulaAuth/Theme/WindowStyle/WindowStyle.xaml
@@ -36,7 +36,8 @@
                         <!--  Window Buttons  -->
                         <StackPanel
                             HorizontalAlignment="Right"
-                            Orientation="Horizontal">
+                            Orientation="Horizontal"
+                            TextElement.Foreground="{DynamicResource PrimaryContentBrush}">
                             <StackPanel.Resources>
                                 <Style TargetType="materialDesign:PackIcon">
                                     <Setter Property="HorizontalAlignment" Value="Center" />

--- a/src/NebulaAuth/View/Dialogs/ConfirmCancelDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/ConfirmCancelDialog.xaml
@@ -12,31 +12,10 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <!--<materialDesign:PackIcon Kind="WarningCircleOutline" Width="20" Height="20" Margin="0,0,5,0"
-                                       VerticalAlignment="Center"
-                                       Foreground="{DynamicResource PrimaryContentBrush}" />-->
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr ConfirmCancelDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{StaticResource False}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <Grid Grid.Row="2" Margin="12">
+        <nebulaAuth:DialogHeader Title="{Tr ConfirmCancelDialog.Title}"
+                                 CloseParameter="{StaticResource False}" />
+        <Grid Grid.Row="1" Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/LoginAgainDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/LoginAgainDialog.xaml
@@ -6,6 +6,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:other="clr-namespace:NebulaAuth.ViewModel.Other"
              xmlns:model="clr-namespace:NebulaAuth.Model"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              TextElement.Foreground="{DynamicResource BaseContentBrush}"
              d:DataContext="{d:DesignInstance other:LoginAgainVM}"
@@ -15,31 +16,11 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Login" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr LoginAgainDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{StaticResource False}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <Grid Grid.Row="2" Margin="12">
+        <nebulaAuth:DialogHeader IconKind="Login"
+                                 Title="{Tr LoginAgainDialog.Title}"
+                                 CloseParameter="{StaticResource False}" />
+        <Grid Grid.Row="1" Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/LoginAgainOnImportDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/LoginAgainOnImportDialog.xaml
@@ -7,6 +7,7 @@
              xmlns:other="clr-namespace:NebulaAuth.ViewModel.Other"
              xmlns:model="clr-namespace:NebulaAuth.Model"
              xmlns:entities="clr-namespace:NebulaAuth.Model.Entities"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              TextElement.Foreground="{DynamicResource BaseContentBrush}"
              d:DataContext="{d:DesignInstance other:LoginAgainVM}"
@@ -16,32 +17,12 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Login" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontSize="16" VerticalAlignment="Center" Foreground="{DynamicResource BaseContentBrush}"
-                           Margin="7,0,0,0" HorizontalAlignment="Left">
-                    <Run Text="{Tr LoginAgainDialog.LoginFor, IsDynamic=False}" />
-                    <Run FontWeight="Bold" Text="{Binding UserName}" />
-                </TextBlock>
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{StaticResource False}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <Grid Grid.Row="2" Margin="12">
+        <nebulaAuth:DialogHeader IconKind="Login"
+                                 Title="{Tr LoginAgainDialog.LoginFor, IsDynamic=False}"
+                                 TitleAccent="{Binding UserName}"
+                                 CloseParameter="{StaticResource False}" />
+        <Grid Grid.Row="1" Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/MafileImportDialog.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              Height="Auto" Width="Auto" MaxWidth="520"
              Background="{DynamicResource WindowBackground}">
@@ -11,27 +12,11 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                       HorizontalAlignment="Left"
-                       VerticalAlignment="Center" FontSize="18" Text="{Tr MafileImportDialog.Title}" />
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{x:Null}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
+        <nebulaAuth:DialogHeader Title="{Tr MafileImportDialog.Title}" />
 
-        <Separator Grid.Row="1" Opacity="0.7" />
-
-        <Grid Grid.Row="2" Margin="14,14,14,16">
+        <Grid Grid.Row="1" Margin="14,14,14,16">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/SdaPasswordDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/SdaPasswordDialog.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:other="clr-namespace:NebulaAuth.ViewModel.Other"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              TextElement.Foreground="{DynamicResource BaseContentBrush}"
              d:DataContext="{d:DesignInstance other:SdaPasswordDialogVM}"
@@ -14,29 +15,11 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Lock" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontSize="16" VerticalAlignment="Center" Foreground="{DynamicResource BaseContentBrush}"
-                           Margin="7,0,0,0" HorizontalAlignment="Left"
-                           Text="{Tr SdaPasswordDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{StaticResource False}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <Grid Grid.Row="2" Margin="12">
+        <nebulaAuth:DialogHeader IconKind="Lock"
+                                 Title="{Tr SdaPasswordDialog.Title}"
+                                 CloseParameter="{StaticResource False}" />
+        <Grid Grid.Row="1" Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/SetCryptPasswordDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/SetCryptPasswordDialog.xaml
@@ -5,8 +5,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:other="clr-namespace:NebulaAuth.ViewModel.Other"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance other:LoginAgainVM}">
+             d:DataContext="{d:DesignInstance other:LoginAgainVM}"
+             Background="{DynamicResource WindowBackground}">
 
 
     <Grid MinHeight="100" MinWidth="300" MaxWidth="400">
@@ -15,38 +17,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Encryption" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr SetEncryptionPasswordDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{StaticResource False}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <TextBlock Grid.Row="2" IsHitTestVisible="False" TextWrapping="Wrap" FontWeight="Normal"
+        <nebulaAuth:DialogHeader IconKind="Encryption"
+                                 Title="{Tr SetEncryptionPasswordDialog.Title}"
+                                 CloseParameter="{StaticResource False}" />
+        <TextBlock Grid.Row="1" IsHitTestVisible="False" TextWrapping="Wrap" FontWeight="Normal"
                    FontSize="16"
                    Text="{Tr SetEncryptionPasswordDialog.DialogText}"
                    Margin="10" HorizontalAlignment="Left" />
         <PasswordBox TabIndex="0" FontSize="16" x:Name="PasswordBox"
                      materialDesign:PasswordBoxAssist.Password="{Binding Password, UpdateSourceTrigger=PropertyChanged}"
-                     Margin="10" Grid.Row="3" Style="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}"
+                     Margin="10" Grid.Row="2" Style="{StaticResource MaterialDesignFloatingHintRevealPasswordBox}"
                      materialDesign:HintAssist.Hint="{Tr SetEncryptionPasswordDialog.Password}" />
-        <Grid Grid.Row="4" Margin="10">
+        <Grid Grid.Row="3" Margin="10">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition />

--- a/src/NebulaAuth/View/Dialogs/TextFieldDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/TextFieldDialog.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              Height="Auto" Width="Auto" MaxWidth="500"
              Background="{DynamicResource WindowBackground}">
@@ -11,31 +12,10 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <!--<materialDesign:PackIcon Kind="WarningCircleOutline" Width="20" Height="20" Margin="0,0,5,0"
-                                       VerticalAlignment="Center"
-                                       Foreground="{DynamicResource PrimaryContentBrush}" />-->
-                <TextBlock x:Name="TitleTextBlock" FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr TextFieldDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" CommandParameter="{x:Null}"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" Opacity="0.7" />
-        <Grid Grid.Row="2" Margin="12">
+        <nebulaAuth:DialogHeader x:Name="TitleHeader"
+                                 Title="{Tr TextFieldDialog.Title}" />
+        <Grid Grid.Row="1" Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/NebulaAuth/View/Dialogs/TextFieldDialog.xaml.cs
+++ b/src/NebulaAuth/View/Dialogs/TextFieldDialog.xaml.cs
@@ -14,7 +14,7 @@ public partial class TextFieldDialog
         InitializeComponent();
 
         if (!string.IsNullOrWhiteSpace(title))
-            TitleTextBlock.Text = title;
+            TitleHeader.Title = title;
 
         if (!string.IsNullOrEmpty(msg))
             HintAssist.SetHint(TextField, msg);

--- a/src/NebulaAuth/View/Dialogs/UpdateDialog.xaml
+++ b/src/NebulaAuth/View/Dialogs/UpdateDialog.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:other="clr-namespace:NebulaAuth.ViewModel.Other"
+             xmlns:nebulaAuth="clr-namespace:NebulaAuth"
              mc:Ignorable="d"
              TextElement.Foreground="{DynamicResource BaseContentBrush}"
              d:DataContext="{d:DesignInstance other:UpdateDialogVM}"
@@ -15,37 +16,15 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="Update" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18">
-                    <Run Text="{Tr UpdateDialog.Title, IsDynamic=False}" />
-                    <Run FontWeight="Bold" Text="{Binding Version, Mode=OneWay}" />
-                </TextBlock>
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right"
-                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-
-        <Separator Grid.Row="1" Opacity="0.7" />
+        <nebulaAuth:DialogHeader IconKind="Update"
+                                 Title="{Tr UpdateDialog.Title, IsDynamic=False}"
+                                 TitleAccent="{Binding Version, Mode=OneWay}" />
 
         <!-- Changelog -->
-        <Grid Grid.Row="2" Margin="12,10,12,4">
+        <Grid Grid.Row="1" Margin="12,10,12,4">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -120,7 +99,7 @@
         </Grid>
 
         <!-- Buttons -->
-        <Grid Grid.Row="3" Margin="12,6,12,14">
+        <Grid Grid.Row="2" Margin="12,6,12,14">
 
             <!-- Normal buttons -->
             <StackPanel

--- a/src/NebulaAuth/View/LinkerView.xaml
+++ b/src/NebulaAuth/View/LinkerView.xaml
@@ -56,30 +56,7 @@
                 </Style.Triggers>
             </Style>
         </Grid.Resources>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="LinkBoxOutline" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr LinkerDialog.Title}" />
-                <TextBlock Margin="5,0,0,0" VerticalAlignment="Center" FontSize="12">
-                    <Hyperlink Command="{Binding OpenTroubleshootingCommand}">
-                        <Run Text="{Tr LinkerDialog.GotErrorHyperlinkText, IsDynamic=False}" />
-                    </Hyperlink>
-                </TextBlock>
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-        <Separator Background="DarkGray" Opacity="0.4" Grid.Row="1" />
+        <nebulaAuth:DialogHeader IconKind="LinkBoxOutline" Title="{Tr LinkerDialog.Title}" />
         <nebulaAuth:HintBox FontSize="14"
                             Visibility="{Binding Tip, Converter={StaticResource NullableToVisibilityConverter}}"
                             Grid.Row="2" Margin="10,10,10,0"

--- a/src/NebulaAuth/View/MafileExporterView.xaml
+++ b/src/NebulaAuth/View/MafileExporterView.xaml
@@ -19,32 +19,12 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="FileExport" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr ExportDialog.ExportTitle}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                    IsCancel="True">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-        <Separator Background="DarkGray" Opacity="0.4" Grid.Row="1" />
-        <Grid Grid.Row="2" Margin="15" TextElement.FontSize="14">
+        <nebulaAuth:DialogHeader IconKind="FileExport" Title="{Tr ExportDialog.ExportTitle}" />
+        <Grid Grid.Row="1" Margin="15" TextElement.FontSize="14">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition />
@@ -233,8 +213,8 @@
 
 
         </Grid>
-        <Separator Grid.Row="3" />
-        <Button Command="{Binding ExportCommand}" Style="{StaticResource MaterialDesignFlatDarkBgButton}" Grid.Row="4"
+        <Separator Grid.Row="2" />
+        <Button Command="{Binding ExportCommand}" Style="{StaticResource MaterialDesignFlatDarkBgButton}" Grid.Row="3"
                 Margin="20,7,20,7" MaxWidth="150" Content="{Tr ExportDialog.ExportButton}" />
     </Grid>
 </UserControl>

--- a/src/NebulaAuth/View/MafileMoverView.xaml
+++ b/src/NebulaAuth/View/MafileMoverView.xaml
@@ -29,9 +29,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-
-
         </Grid.RowDefinitions>
         <Grid.Resources>
             <Style TargetType="materialDesign:PackIcon">
@@ -58,35 +55,17 @@
                 </Style.Triggers>
             </Style>
         </Grid.Resources>
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <materialDesign:PackIcon Kind="FileMove" Width="20" Height="20" Margin="0,0,5,0"
-                                         VerticalAlignment="Center"
-                                         Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr MafileMoverView.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}">
-                <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-        <Separator Background="DarkGray" Opacity="0.4" Grid.Row="1" />
+        <nebulaAuth:DialogHeader IconKind="FileMove" Title="{Tr MafileMoverView.Title}" />
         <nebulaAuth:HintBox FontSize="14"
                             Visibility="{Binding Tip, Converter={StaticResource NullableToVisibilityConverter}}"
-                            Grid.Row="2" Margin="10,10,10,0"
+                            Grid.Row="1" Margin="10,10,10,0"
                             Text="{Binding Tip}" />
         <ContentControl
-            Grid.Row="3" Margin="20" Content="{Binding CurrentStep}" />
+            Grid.Row="2" Margin="20" Content="{Binding CurrentStep}" />
 
         <nebulaAuth:HintBox FontSize="14"
                             Visibility="{Binding Error, Converter={StaticResource NullableToVisibilityConverter}}"
-                            Grid.Row="4" Margin="10,0,10,10"
+                            Grid.Row="3" Margin="10,0,10,10"
                             Text="{Binding Error}" />
     </Grid>
 </UserControl>

--- a/src/NebulaAuth/View/ProxyManagerView.xaml
+++ b/src/NebulaAuth/View/ProxyManagerView.xaml
@@ -21,33 +21,13 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <!-- Title -->
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <md:PackIcon Kind="Proxy" Width="20" Height="20" Margin="0,0,5,0" VerticalAlignment="Center"
-                             Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center" FontSize="18" Text="{Tr ProxyManagerDialog.Title}" />
-            </StackPanel>
-            <Button Grid.Column="1" Width="30" Height="30" Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right" Command="{x:Static md:DialogHost.CloseDialogCommand}"
-                    IsCancel="True">
-                <md:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-        <Separator Grid.Row="1" />
+        <nebulaAuth:DialogHeader IconKind="Proxy" Title="{Tr ProxyManagerDialog.Title}" />
 
         <!-- Tabs -->
-        <TabControl Grid.Row="2"
+        <TabControl Grid.Row="1"
                     md:ColorZoneAssist.Background="{DynamicResource Base100Brush}"
                     Style="{StaticResource MaterialDesignUniformTabControl}">
 

--- a/src/NebulaAuth/View/SetAccountPasswordsView.xaml
+++ b/src/NebulaAuth/View/SetAccountPasswordsView.xaml
@@ -22,43 +22,16 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!-- ===== HEADER ===== -->
-        <Grid Margin="10,10,10,5">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-
-            <StackPanel Orientation="Horizontal">
-                <md:PackIcon Kind="ShieldKey" Width="20" Height="20"
-                             Margin="0,0,5,0" VerticalAlignment="Center"
-                             Foreground="{DynamicResource PrimaryContentBrush}" />
-                <TextBlock Text="{Tr SetAccountPasswordsView.Title}"
-                           FontSize="18"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource BaseContentBrush}" />
-            </StackPanel>
-
-            <Button Grid.Column="1" Width="30" Height="30"
-                    Style="{StaticResource MaterialDesignIconForegroundButton}"
-                    HorizontalAlignment="Right"
-                    Command="{x:Static md:DialogHost.CloseDialogCommand}"
-                    IsCancel="True">
-                <md:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-            </Button>
-        </Grid>
-
-        <Separator Grid.Row="1" />
+        <nebulaAuth:DialogHeader IconKind="ShieldKey" Title="{Tr SetAccountPasswordsView.Title}" />
 
         <!-- ===== ENCRYPTION PASSWORD SECTION ===== -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition />
                 <RowDefinition />
@@ -109,7 +82,7 @@
 
 
         <!-- ===== ACCOUNTS INPUT ===== -->
-        <TextBox Grid.Row="3"
+        <TextBox Grid.Row="2"
                  Margin="15,0,15,10"
                  Text="{Binding AccountsPasswords, UpdateSourceTrigger=PropertyChanged}"
                  FontSize="13"
@@ -124,14 +97,14 @@
                  md:TextFieldAssist.TextBoxViewVerticalAlignment="Top"
                  VerticalContentAlignment="Top" />
         <!-- ===== INFO TEXT ===== -->
-        <TextBlock Grid.Row="4"
+        <TextBlock Grid.Row="3"
                    Margin="20,0,20,15"
                    TextWrapping="Wrap"
                    FontSize="12"
                    Foreground="{DynamicResource BaseContentBrush}"
                    Text="{Tr SetAccountPasswordsView.EncryptionHint}" />
 
-        <Button Grid.Row="5"
+        <Button Grid.Row="4"
                 Margin="10,0,0,10"
                 Width="120"
                 Content="{Tr Common.Save}"
@@ -139,7 +112,7 @@
                 Style="{StaticResource MaterialDesignOutlinedButton}" Cursor="Hand" />
 
         <!-- ===== HINT / RESULT BOX ===== -->
-        <nebulaAuth:HintBox Grid.Row="6"
+        <nebulaAuth:HintBox Grid.Row="5"
                             Margin="15,0,15,10"
                             Visibility="{Binding Tip, Converter={StaticResource NullableToVisibilityConverter}}"
                             CloseCommand="{Binding ClearTipCommand}"

--- a/src/NebulaAuth/View/SettingsView.xaml
+++ b/src/NebulaAuth/View/SettingsView.xaml
@@ -19,35 +19,14 @@
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
-
             </Grid.RowDefinitions>
-            <Grid Margin="10,10,10,5">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Orientation="Horizontal">
-                    <materialDesign:PackIcon Kind="Settings" Width="20" Height="20" Margin="0,0,5,0"
-                                             VerticalAlignment="Center"
-                                             Foreground="{DynamicResource PrimaryContentBrush}" />
-                    <TextBlock FontStyle="Normal" Foreground="{DynamicResource BaseContentBrush}"
-                               HorizontalAlignment="Left"
-                               VerticalAlignment="Center" FontSize="18" Text="{Tr SettingsDialog.Title}" />
-                </StackPanel>
-                <Button Grid.Column="1" Width="30" Height="30"
-                        Style="{StaticResource MaterialDesignIconForegroundButton}"
-                        HorizontalAlignment="Right" Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
-                        IsEnabled="{Binding ApplyRenameSettingCommand.IsRunning, Converter={StaticResource ReverseBooleanConverter}, Mode=OneWay}"
-                        IsCancel="True">
-                    <materialDesign:PackIcon Kind="Close" Width="24" Height="24" Foreground="IndianRed" />
-                </Button>
-            </Grid>
-            <Separator Grid.Row="1" Margin="0,10,0,0" />
+            <nebulaAuth:DialogHeader IconKind="Settings"
+                                     Title="{Tr SettingsDialog.Title}"
+                                     IsCloseEnabled="{Binding ApplyRenameSettingCommand.IsRunning, Converter={StaticResource ReverseBooleanConverter}, Mode=OneWay}" />
 
             <TabControl materialDesign:ColorZoneAssist.Background="{DynamicResource Base100Brush}"
-                        Style="{StaticResource MaterialDesignUniformTabControl}" Grid.Row="2">
+                        Style="{StaticResource MaterialDesignUniformTabControl}" Grid.Row="1">
                 <TabItem Header="{Tr SettingsDialog.MainSettings}">
                     <StackPanel Width="400" Margin="10,18,10,40" Orientation="Vertical" HorizontalAlignment="Center">
                         <ComboBox Style="{StaticResource MaterialDesignFloatingHintComboBox}" Margin="0,15,0,0"


### PR DESCRIPTION
## Summary

Introduce a reusable `DialogHeader` UserControl that provides a consistent colored header (using `Base300Brush`) with an icon, title, optional bold accent, and a close button. Migrated all dialogs and modal views to use the component, eliminating ~270 lines of duplicated header markup. Also fix window control buttons being invisible in the ShadCN theme by applying `PrimaryContentBrush` to the title bar button stack.

## Changes

- Added: `View/Controls/DialogHeader` — new reusable UserControl with `IconKind`, `Title`, `TitleAccent`, `CloseParameter`, `IsCloseEnabled` dependency properties
- Changed: All dialog headers migrated to `controls:DialogHeader` — `SettingsView`, `ConfirmCancelDialog`, `LoginAgainDialog`, `LoginAgainOnImportDialog`, `UpdateDialog`, `TextFieldDialog`, `SetCryptPasswordDialog`, `SdaPasswordDialog`, `MafileImportDialog`, `SetAccountPasswordsView`, `ProxyManagerView`, `MafileMoverView`, `MafileExporterView`, `LinkerView`