### PR TITLE
feat(links): fetch website and docs URLs from GitHub at startup

### DIFF
--- a/NebulaAuth/links.json
+++ b/NebulaAuth/links.json
@@ -1,0 +1,4 @@
+{
+  "Website": "https://achiefy.pro/?nebula=true",
+  "Documentation": "https://achiefy-project.gitbook.io/nebulaauth"
+}

--- a/src/NebulaAuth/Core/LinksManager.cs
+++ b/src/NebulaAuth/Core/LinksManager.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NebulaAuth.Model;
+using Newtonsoft.Json;
+
+namespace NebulaAuth.Core;
+
+public static class LinksManager
+{
+    private const string LINKS_URL =
+        "https://raw.githubusercontent.com/achiez/NebulaAuth-Steam-Desktop-Authenticator-by-Achies/master/NebulaAuth/links.json";
+
+    private static readonly HttpClient HttpClient = new();
+
+    public static string? WebsiteUrl { get; private set; }
+    public static string? DocumentationUrl { get; private set; }
+
+    public static async Task FetchAsync()
+    {
+        try
+        {
+            var json = await HttpClient.GetStringAsync(LINKS_URL).ConfigureAwait(false);
+            var links = JsonConvert.DeserializeObject<RemoteLinks>(json);
+            WebsiteUrl = links?.Website;
+            DocumentationUrl = links?.Documentation;
+        }
+        catch (Exception ex)
+        {
+            Shell.Logger.Debug(ex, "Failed to fetch remote links");
+        }
+    }
+}

--- a/src/NebulaAuth/Model/RemoteLinks.cs
+++ b/src/NebulaAuth/Model/RemoteLinks.cs
@@ -1,0 +1,7 @@
+namespace NebulaAuth.Model;
+
+public class RemoteLinks
+{
+    public string? Website { get; set; }
+    public string? Documentation { get; set; }
+}

--- a/src/NebulaAuth/Model/Shell.cs
+++ b/src/NebulaAuth/Model/Shell.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NebulaAuth.Core;
-using NebulaAuth.Model.Exceptions;
 using NebulaAuth.Model.MAAC;
 using NebulaAuth.Model.MafileExport;
 using NebulaAuth.Model.Mafiles;
@@ -40,7 +39,8 @@ public static class Shell
         }
         catch (Exception ex)
         {
-            throw new CantAlignTimeException("", ex);
+            Logger.Error(ex, "Failed to align time with Steam");
+            TimeAligner.SetTimeDifference(0);
         }
 
         var threads = Environment.ProcessorCount > 0 ? Environment.ProcessorCount : 1;
@@ -48,6 +48,7 @@ public static class Shell
         ProxyAssignmentCache.Initialize(Storage.MaFiles);
         MAACStorage.Initialize();
         MafileExporterStorage.Initialize();
+        _ = LinksManager.FetchAsync();
 
         ExtensionsLogger.LogDebug("Application started");
     }

--- a/src/NebulaAuth/View/LinksView.xaml
+++ b/src/NebulaAuth/View/LinksView.xaml
@@ -8,7 +8,8 @@
              d:DesignHeight="450" d:DesignWidth="800"
              TextElement.Foreground="{DynamicResource BaseContentBrush}"
              Background="Transparent"
-             RenderOptions.BitmapScalingMode="HighQuality">
+             RenderOptions.BitmapScalingMode="HighQuality"
+             Loaded="LinksView_Loaded">
 
     <materialDesign:Card Padding="24" HorizontalAlignment="Center" VerticalAlignment="Center" UniformCornerRadius="12">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
@@ -49,16 +50,20 @@
                 </StackPanel>
             </Button>
 
-            <Button Margin="0,0,0,5" FontSize="18" Style="{StaticResource MaterialDesignFlatButton}"
-                    Click="Website_Click" IsEnabled="False">
+            <Button x:Name="WebsiteButton" Margin="0,0,0,5" FontSize="18"
+                    Style="{StaticResource MaterialDesignFlatButton}"
+                    IsEnabled="False"
+                    Click="Website_Click">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <materialDesign:PackIcon Kind="Web" Width="24" Height="24" Margin="0 0 8 0" />
-                    <TextBlock Text="Web-site" VerticalAlignment="Center" />
+                    <TextBlock Text="Achiefy" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
 
-            <Button Margin="0,0,0,5" FontSize="18" Style="{StaticResource MaterialDesignFlatButton}"
-                    Click="Documentation_Click" IsEnabled="False">
+            <Button x:Name="DocumentationButton" Margin="0,0,0,5" FontSize="18"
+                    Style="{StaticResource MaterialDesignFlatButton}"
+                    IsEnabled="False"
+                    Click="Documentation_Click">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                     <Viewbox Width="22" Height="22" Margin="0 0 8 0">
                         <Canvas Width="22" Height="22">

--- a/src/NebulaAuth/View/LinksView.xaml.cs
+++ b/src/NebulaAuth/View/LinksView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using MaterialDesignThemes.Wpf;
@@ -11,6 +11,12 @@ public partial class LinksView : UserControl
     public LinksView()
     {
         InitializeComponent();
+    }
+
+    private void LinksView_Loaded(object sender, RoutedEventArgs e)
+    {
+        WebsiteButton.IsEnabled = LinksManager.WebsiteUrl != null;
+        DocumentationButton.IsEnabled = LinksManager.DocumentationUrl != null;
     }
 
     private void Telegram_Click(object sender, RoutedEventArgs e)
@@ -26,12 +32,14 @@ public partial class LinksView : UserControl
 
     private void Website_Click(object sender, RoutedEventArgs e)
     {
-        Process.Start(new ProcessStartInfo("https://yourwebsite.com") {UseShellExecute = true});
+        if (LinksManager.WebsiteUrl != null)
+            Process.Start(new ProcessStartInfo(LinksManager.WebsiteUrl) {UseShellExecute = true});
     }
 
     private void Documentation_Click(object sender, RoutedEventArgs e)
     {
-        Process.Start(new ProcessStartInfo("https://yourwebsite.com") {UseShellExecute = true});
+        if (LinksManager.DocumentationUrl != null)
+            Process.Start(new ProcessStartInfo(LinksManager.DocumentationUrl) {UseShellExecute = true});
     }
 
     private void CheckForUpdates_Click(object sender, RoutedEventArgs e)

--- a/src/SteamLibForked/SteamMobile/TimeAligner.cs
+++ b/src/SteamLibForked/SteamMobile/TimeAligner.cs
@@ -80,4 +80,10 @@ public static class TimeAligner
             client.Dispose();
         }
     }
+
+    public static void SetTimeDifference(int timeDifference)
+    {
+        _timeDifference = timeDifference;
+        _aligned = true;
+    }
 }


### PR DESCRIPTION
## Summary

- **Remote links**: `links.json` added to repository (next to `update.xml`).  `LinksManager` fetches it from GitHub at startup — Website and Documentation  buttons in LinksView activate only when URLs are loaded.
- **Startup fix**: time synchronization failure with Steam no longer blocks app  launch. Previously `CantAlignTimeException` propagated to the startup crash  handler; now it is caught and ignored with time diff set to 0.